### PR TITLE
allow to pass options into guzzle client via the constructor

### DIFF
--- a/src/APIClient.php
+++ b/src/APIClient.php
@@ -40,16 +40,53 @@ class APIClient
     private $credentials;
 
     /**
+     * Key value array containing client options for GuzzleClient
+     *
+     *
+     * @var array
+     */
+    private $clientOptions = [];
+
+    /**
      * APIClient constructor.
      * @param string $baseURI
      * @param ApiCredentials $credentials
+     * @param array $options
      */
-    public function __construct($baseURI, ApiCredentials $credentials = null)
+    public function __construct($baseURI, ApiCredentials $credentials = null, array $options = [])
     {
         $this->setBaseURI($baseURI);
         if ($credentials) {
             $this->setCredentials($credentials);
         }
+        if ($options) {
+            $this->setClientOptions($options);
+        }
+    }
+
+    /**
+     * Create an Authenticated APIClient
+     *
+     * @param $baseURI
+     * @param ApiCredentials $credentials
+     * @param array $options
+     * @return APIClient
+     */
+    public static function createAuthenticatedClient($baseURI, ApiCredentials $credentials, array $options = [])
+    {
+        return new APIClient($baseURI, $credentials, $options);
+    }
+
+    /**
+     * Create an unauthenticated APIClient
+     *
+     * @param $baseURI
+     * @param array $options
+     * @return APIClient
+     */
+    public static function createClient($baseURI, array $options = [])
+    {
+        return new APIClient($baseURI, null, $options);
     }
 
     /**
@@ -110,6 +147,16 @@ class APIClient
      */
     private function createNewClient()
     {
+        $clientOptions = $this->generateClientOptions();
+
+        return new Client($clientOptions);
+    }
+
+    /**
+     * @return array
+     */
+    private function generateClientOptions()
+    {
         $clientOptions = [
             'base_uri' => $this->getBaseURI(),
             'timeout' => self::REQUEST_TIMEOUT
@@ -121,7 +168,9 @@ class APIClient
             $clientOptions['handler'] = $stack;
         }
 
-        return new Client($clientOptions);
+        $clientOptions = $this->getClientOptions() + $clientOptions;
+
+        return $clientOptions;
     }
 
     /**
@@ -254,5 +303,33 @@ class APIClient
     public function setCredentials(ApiCredentials $credentials)
     {
         $this->credentials = $credentials;
+    }
+
+    /**
+     * @return array
+     */
+    private function getClientOptions()
+    {
+        return $this->clientOptions;
+    }
+
+    /**
+     * @param array $clientOptions
+     */
+    private function setClientOptions(array $clientOptions)
+    {
+        $this->clientOptions = [];
+        foreach ($clientOptions as $key => $clientOption) {
+            $this->addClientOption($key, $clientOption);
+        }
+    }
+
+    /**
+     * @param $optionName
+     * @param $optionValue
+     */
+    private function addClientOption($optionName, $optionValue)
+    {
+        $this->clientOptions[$optionName] = $optionValue;
     }
 }

--- a/tests/APIClientTest.php
+++ b/tests/APIClientTest.php
@@ -5,6 +5,7 @@ namespace BernardoSilva\JWTAPIClient\Tests;
 use BernardoSilva\JWTAPIClient\AccessTokenCredentials;
 use BernardoSilva\JWTAPIClient\APIClient;
 use BernardoSilva\JWTAPIClient\UsernameAndPasswordCredentials;
+use GuzzleHttp\HandlerStack;
 use PHPUnit\Framework\TestCase;
 
 final class APIClientTest extends TestCase
@@ -63,8 +64,63 @@ final class APIClientTest extends TestCase
         $credentials = new AccessTokenCredentials($accessToken);
         $client = new APIClient($baseURI, $credentials);
 
-        $this->setClient($client);
+        $this->assertInstanceOf(AccessTokenCredentials::class, $client->getCredentials());
+    }
 
-        $this->assertInstanceOf(AccessTokenCredentials::class, $this->getClient()->getCredentials());
+    public function testGenerateClientOptionsContainsStackCallbackToAddTokenHeader()
+    {
+        $baseURI = 'https://api.chefs-em-casa.dev';
+        $accessToken = 'user-jwt-token';
+        $credentials = new AccessTokenCredentials($accessToken);
+        $apiClient = new APIClient($baseURI, $credentials);
+
+        $reflector = new \ReflectionClass(APIClient::class);
+        $method = $reflector->getMethod('generateClientOptions');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs($apiClient, []);
+
+        $this->assertInstanceOf(HandlerStack::class, $result['handler']);
+    }
+
+    public function testGenerateClientOptionsContainDefaultValues()
+    {
+        $apiClient = new APIClient('https://my-api.com');
+
+        $reflector = new \ReflectionClass(APIClient::class);
+        $method = $reflector->getMethod('generateClientOptions');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs($apiClient, []);
+
+        $expectedOptions = [
+            'base_uri' => 'https://my-api.com',
+            'timeout' => 5
+        ];
+
+        $this->assertEquals($expectedOptions, $result);
+    }
+
+    public function testGenerateClientOptionsOverrideDefaults()
+    {
+        $options = [
+            'timeout' => 30,
+            'verify' => false
+        ];
+        $apiClient = new APIClient('https://my-api.com', null, $options);
+
+        $reflector = new \ReflectionClass(APIClient::class);
+        $method = $reflector->getMethod('generateClientOptions');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs($apiClient, []);
+
+        $expectedOptions = [
+            'base_uri' => 'https://my-api.com',
+            'timeout' => 30,
+            'verify' => false
+        ];
+
+        $this->assertEquals($expectedOptions, $result);
     }
 }


### PR DESCRIPTION
This will allow developers to pass in clientOptions to be used by GuzzleClient internally when creating the client.
This will also allow to override any default value that is set by this APIClient.

fixes #5 

Usage example:

```php
$options = [
    'timeout' => 30,
    'verify' => false
];
$apiClient = new APIClient('https://my-api.com', null, $options);
```
This will override the timeout default option of 5s to 30s and set `verify` to false to prevent the client from checking ssl certificates